### PR TITLE
Check_process improvements

### DIFF
--- a/check_process
+++ b/check_process
@@ -20,3 +20,14 @@
         fail_download_source=0
         port_already_use=1  (5050)
         final_path_already_use=0
+;;; Levels
+    Level 1=auto
+    Level 2=auto
+    Level 3=auto
+    Level 4=1
+    Level 5=1
+    Level 6=auto
+    Level 7=auto
+    Level 8=0
+    Level 9=0
+	Level 10=0

--- a/check_process
+++ b/check_process
@@ -24,10 +24,10 @@
     Level 1=auto
     Level 2=auto
     Level 3=auto
-    Level 4=1
-    Level 5=1
+    Level 4=1	# The app is single-user and does not support LDAP. It is therefore protected behind SSO.
+    Level 5=1	# See https://github.com/YunoHost/package_linter/issues/15
     Level 6=auto
     Level 7=auto
     Level 8=0
     Level 9=0
-	Level 10=0
+    Level 10=0

--- a/check_process
+++ b/check_process
@@ -24,8 +24,10 @@
     Level 1=auto
     Level 2=auto
     Level 3=auto
-    Level 4=1	# The app is single-user and does not support LDAP. It is therefore protected behind SSO.
-    Level 5=1	# See https://github.com/YunoHost/package_linter/issues/15
+	# The app is single-user and does not support LDAP. It is therefore protected behind SSO.
+    Level 4=1
+	# See https://github.com/YunoHost/package_linter/issues/15
+    Level 5=1
     Level 6=auto
     Level 7=auto
     Level 8=0

--- a/scripts/remove
+++ b/scripts/remove
@@ -1,5 +1,6 @@
 #!/bin/bash
-	#set -eu
+	
+	set -u
 	app=$YNH_APP_INSTANCE_NAME
 
 # Source app helpers

--- a/scripts/restore
+++ b/scripts/restore
@@ -1,4 +1,6 @@
 #!/bin/bash
+
+	set -eu
 	app=$YNH_APP_INSTANCE_NAME
 
 # Source app helpers

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -1,4 +1,6 @@
 #!/bin/bash
+
+	set -eu
 	app=$YNH_APP_INSTANCE_NAME
 	source="https://github.com/CouchPotato/CouchPotatoServer"
 


### PR DESCRIPTION
- Fix set -eu and set -u
Suggest forcing levels 4 and 5:
- **Level 4**: The app does not support LDAP and HTTP auth and is single
user only. However, it is set as passwordless and protected behind the
SSO. All users can share the same CouchPotato instance to manage their
collective libraries.
- **Level 5**: I suppose linter is fine. The failure is the result of
this problem (which I can't explain):
https://github.com/YunoHost/package_linter/issues/15